### PR TITLE
Removed semicolon to get rid of warnings with `-pedantic`

### DIFF
--- a/ArrayBuffer.h
+++ b/ArrayBuffer.h
@@ -384,6 +384,6 @@ namespace node {
 #endif
 
   };
-};
+}
 
 #endif


### PR DESCRIPTION
This was just the only warning in my project.
